### PR TITLE
Add `opponent` command and remove `delete` command

### DIFF
--- a/game.py
+++ b/game.py
@@ -32,11 +32,6 @@ class Game:
         self.history.append(next_state)
         self.future = []
 
-    def delete_question_card(self, idx: int) -> None:
-        next_state = self.current_state().delete_question_card(idx)
-        self.history.append(next_state)
-        self.future = []
-
     """
     You can execute specific commands interactively through the shell-like interface.
     Basically, each commands represent actual actions in the game.
@@ -52,7 +47,6 @@ class Game:
     -- question : Ask a question and obtain information
     -- add : Add the specified card in the deck to the field
     -- opposite : Opposite player asks a question (Obtain info if shared-type one is choosen)
-    -- delete : Remove the specified card from the field to the trash
     - Advanced commands
     -- (none)
     """
@@ -86,12 +80,6 @@ class Game:
                     continue
                 idx, question, answer = result
                 self.opposite_ask(question, answer)
-            elif "delete".startswith(command):
-                idx: int | None = ui.delete(state)
-                if idx is None:
-                    self.set_message("Cancelled `delete`")
-                    continue
-                self.delete_question_card(idx)
             elif "submit".startswith(command):
                 print("`submit` is not implemented now")
                 pass

--- a/game.py
+++ b/game.py
@@ -27,8 +27,8 @@ class Game:
         self.history.append(next_state)
         self.future = []
 
-    def opposite_ask(self, question: Question, answer: Answer | None):
-        next_state = self.current_state().opposite_ask(question, answer)
+    def opponent_ask(self, question: Question, answer: Answer | None):
+        next_state = self.current_state().opponent_ask(question, answer)
         self.history.append(next_state)
         self.future = []
 
@@ -46,7 +46,7 @@ class Game:
     - Basic commands
     -- question : Ask a question and obtain information
     -- add : Add the specified card in the deck to the field
-    -- opposite : Opposite player asks a question (Obtain info if shared-type one is choosen)
+    -- opponent : Opponent asks a question (Obtain info if shared-type one is choosen)
     - Advanced commands
     -- (none)
     """
@@ -73,13 +73,13 @@ class Game:
                     self.set_message("Cancelled `add`")
                     continue
                 self.add_question_card(idx)
-            elif "opposite".startswith(command):
-                result = ui.opposite(state)
+            elif "opponent".startswith(command):
+                result = ui.opponent(state)
                 if result is None:
-                    self.set_message("Cancelled `opposite`")
+                    self.set_message("Cancelled `opponent`")
                     continue
                 idx, question, answer = result
-                self.opposite_ask(question, answer)
+                self.opponent_ask(question, answer)
             elif "submit".startswith(command):
                 print("`submit` is not implemented now")
                 pass

--- a/game.py
+++ b/game.py
@@ -27,6 +27,11 @@ class Game:
         self.history.append(next_state)
         self.future = []
 
+    def opposite_ask(self, question: Question, answer: Answer | None):
+        next_state = self.current_state().opposite_ask(question, answer)
+        self.history.append(next_state)
+        self.future = []
+
     def delete_question_card(self, idx: int) -> None:
         next_state = self.current_state().delete_question_card(idx)
         self.history.append(next_state)
@@ -46,6 +51,7 @@ class Game:
     - Basic commands
     -- question : Ask a question and obtain information
     -- add : Add the specified card in the deck to the field
+    -- opposite : Opposite player asks a question (Obtain info if shared-type one is choosen)
     -- delete : Remove the specified card from the field to the trash
     - Advanced commands
     -- (none)
@@ -73,6 +79,13 @@ class Game:
                     self.set_message("Cancelled `add`")
                     continue
                 self.add_question_card(idx)
+            elif "opposite".startswith(command):
+                result = ui.opposite(state)
+                if result is None:
+                    self.set_message("Cancelled `opposite`")
+                    continue
+                idx, question, answer = result
+                self.opposite_ask(question, answer)
             elif "delete".startswith(command):
                 idx: int | None = ui.delete(state)
                 if idx is None:

--- a/qanda.py
+++ b/qanda.py
@@ -48,7 +48,7 @@ class Answer:
         elif self.type in (QuestionType.COUNT, QuestionType.SUM):
             assert isinstance(self.value, int)
         elif self.type == QuestionType.SHARED:
-            raise NotImplementedError
+            assert isinstance(self.value, int)
         else:
             assert False
 
@@ -114,6 +114,22 @@ def ca_sum_red_blue(hand: Hand, blue: bool = False) -> int:
     return sum(nums)
 
 
+def ca_shared_sum_all(hand: Hand) -> int:
+    nums = [tile.num for tile in hand.tiles]
+    return sum(nums)
+
+
+def ca_shared_center_45(hand: Hand) -> int:
+    center_tile = hand.tiles[2]
+    return 5 if center_tile.num >= 5 else 4
+
+
+def ca_shared_diff_min_max(hand: Hand) -> int:
+    min_tile = hand.tiles[0]
+    max_tile = hand.tiles[4]
+    return max_tile.num - min_tile.num
+
+
 class QuestionCard:
     def __init__(self, qcid: QuestionCardId, ja: str, en: str):
         self.id = qcid
@@ -146,8 +162,6 @@ class QuestionCard:
             return [Question(self, 6), Question(self, 7)]
         if self.id == QuestionCardId.WHERE_89:
             return [Question(self, 8), Question(self, 9)]
-        if self.type == QuestionType.SHARED:
-            return []
         return [Question(self)]
 
 
@@ -204,5 +218,11 @@ class Question:
             return ca_sum_red_blue(hand)
         elif self.question_card.id == QuestionCardId.SUM_BLUE:
             return ca_sum_red_blue(hand, blue=True)
+        elif self.question_card.id == QuestionCardId.SHARED_SUM_ALL:
+            return ca_shared_sum_all(hand)
+        elif self.question_card.id == QuestionCardId.SHARED_CENTER_45:
+            return ca_shared_center_45(hand)
+        elif self.question_card.id == QuestionCardId.SHARED_DIFF_MIN_MAX:
+            return ca_shared_diff_min_max(hand)
         else:
             raise NotImplementedError

--- a/state.py
+++ b/state.py
@@ -97,11 +97,3 @@ class State:
         next_state.question_cards_in_field.append(qc)
         next_state.last_action = f"added question card `{qc.id}`"
         return next_state
-
-    def delete_question_card(self, idx: int):
-        assert 0 <= idx < len(self.question_cards_in_field)
-        next_state = self.copy()
-        qc = next_state.question_cards_in_field.pop(idx)
-        next_state.question_cards_in_trash.append(qc)
-        next_state.last_action = f"deleted question card `{qc.id}`"
-        return next_state

--- a/state.py
+++ b/state.py
@@ -77,7 +77,7 @@ class State:
         next_state.last_action = f"narrowed by question {question} and answer {answer}"
         return next_state
 
-    def opposite_ask(self, question: Question, answer: Answer | None):
+    def opponent_ask(self, question: Question, answer: Answer | None):
         next_state = self.copy()
         if question.type == QuestionType.SHARED:
             assert answer is not None
@@ -87,7 +87,7 @@ class State:
             if question.question_card.id == qc.id:
                 next_state.question_cards_in_field.pop(i)
                 next_state.question_cards_in_trash.append(qc)
-        next_state.last_action = f"opposite asked question {question}{f' and answer {answer} narrows' if answer else ''}"
+        next_state.last_action = f"opponent asked question {question}{f' and answer {answer} narrows' if answer else ''}"
         return next_state
 
     def add_question_card(self, idx: int):

--- a/state.py
+++ b/state.py
@@ -3,7 +3,7 @@ import json
 
 import init_phase
 import utility
-from qanda import Answer, Question, QuestionCard, QuestionCardId
+from qanda import Answer, Question, QuestionCard, QuestionCardId, QuestionType
 from utility import Hand
 
 """
@@ -75,6 +75,19 @@ class State:
                 next_state.question_cards_in_field.pop(i)
                 next_state.question_cards_in_trash.append(qc)
         next_state.last_action = f"narrowed by question {question} and answer {answer}"
+        return next_state
+
+    def opposite_ask(self, question: Question, answer: Answer | None):
+        next_state = self.copy()
+        if question.type == QuestionType.SHARED:
+            assert answer is not None
+            groups = self.groupby(question)
+            next_state.candidates = groups[answer.value]
+        for i, qc in enumerate(self.question_cards_in_field):
+            if question.question_card.id == qc.id:
+                next_state.question_cards_in_field.pop(i)
+                next_state.question_cards_in_trash.append(qc)
+        next_state.last_action = f"opposite asked question {question}{f' and answer {answer} narrows' if answer else ''}"
         return next_state
 
     def add_question_card(self, idx: int):

--- a/ui.py
+++ b/ui.py
@@ -110,6 +110,28 @@ def add(state: State) -> int | None:
             continue
 
 
+def opposite(state: State) -> tuple[int, Question, Answer | None] | None:
+    while True:
+        os.system("clear")
+        questions = show_possible_questions(state)
+        idx = input_int("Which question did the opposite ask?")
+        if idx is None:
+            return None
+        if 0 <= idx < len(questions):
+            pass
+        else:
+            continue
+        question = questions[idx]
+        if question.type == QuestionType.SHARED:
+            answer_opt = qa_int(state, question)
+            if answer_opt is None:
+                return None
+            answer = answer_opt
+        else:
+            answer = None
+        return (idx, question, answer)
+
+
 def delete(state: State) -> int | None:
     while True:
         os.system("clear")
@@ -132,5 +154,5 @@ def input_command(state: State, message=""):
     if len(state.candidates) <= 10:
         print("candidates:")
         print(state.candidates)
-    print("`qa` / `add` / `delete` / `submit` / `undo`")
+    print("`qa` / `add` / `opposite` / `delete` / `submit` / `undo`")
     return input("[$] ")

--- a/ui.py
+++ b/ui.py
@@ -132,19 +132,6 @@ def opposite(state: State) -> tuple[int, Question, Answer | None] | None:
         return (idx, question, answer)
 
 
-def delete(state: State) -> int | None:
-    while True:
-        os.system("clear")
-        show_question_cards_in_field(state)
-        idx = input_int("Which question has been deleted?")
-        if idx is None:
-            return None
-        if 0 <= idx < len(state.question_cards_in_field):
-            return idx
-        else:
-            continue
-
-
 def input_command(state: State, message=""):
     os.system("clear")
     show_question_cards_in_field(state)
@@ -154,5 +141,5 @@ def input_command(state: State, message=""):
     if len(state.candidates) <= 10:
         print("candidates:")
         print(state.candidates)
-    print("`qa` / `add` / `opposite` / `delete` / `submit` / `undo`")
+    print("`qa` / `add` / `opposite` / `submit` / `undo`")
     return input("[$] ")

--- a/ui.py
+++ b/ui.py
@@ -110,11 +110,11 @@ def add(state: State) -> int | None:
             continue
 
 
-def opposite(state: State) -> tuple[int, Question, Answer | None] | None:
+def opponent(state: State) -> tuple[int, Question, Answer | None] | None:
     while True:
         os.system("clear")
         questions = show_possible_questions(state)
-        idx = input_int("Which question did the opposite ask?")
+        idx = input_int("Which question did the opponent ask?")
         if idx is None:
             return None
         if 0 <= idx < len(questions):
@@ -141,5 +141,5 @@ def input_command(state: State, message=""):
     if len(state.candidates) <= 10:
         print("candidates:")
         print(state.candidates)
-    print("`qa` / `add` / `opposite` / `submit` / `undo`")
+    print("`qa` / `add` / `opponent` / `submit` / `undo`")
     return input("[$] ")


### PR DESCRIPTION
## Summary

Closes #4
Closes #5

Implement ~~`opposite`~~ `opponent` command, which represents that the opposite player uses a question card.
If they choose one of the shared-type questions, the system asks you to input the information obtained.

By merging this PR, Functionality provided by `delete` command is included in `question` command and ~~`opposite`~~ `opponent` command, so `delete` command is removed.

