### PR TITLE
Replace `qa` -> `question` in command list

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -145,5 +145,5 @@ def input_command(state: State, message=""):
     if len(state.candidates) <= 10:
         print("candidates:")
         print(state.candidates)
-    print("`qa` / `add` / `opponent` / `submit` / `undo`")
+    print("`question` / `add` / `opponent` / `submit` / `undo`")
     return input("[$] ")


### PR DESCRIPTION
## Summary

Fixes #14 . Now you see `question` in the command list instead of `qa`, which was originally the name of the command.
