### PR TITLE
Show dashboard view in command `question`, `add`, `opponent`

### DIFF
--- a/game.py
+++ b/game.py
@@ -63,20 +63,20 @@ class Game:
             if command == "":
                 continue
             elif "question".startswith(command):
-                result = ui.qa(state)
+                result = ui.qa(state, self.message, self.show_all_candidates)
                 if result is None:
                     self.set_message("Cancelled `question`")
                     continue
                 idx, question, answer = result
                 self.narrow_by_qa(question, answer)
             elif "add".startswith(command):
-                idx: int | None = ui.add(state)
+                idx: int | None = ui.add(state, self.message, self.show_all_candidates)
                 if idx is None:
                     self.set_message("Cancelled `add`")
                     continue
                 self.add_question_card(idx)
             elif "opponent".startswith(command):
-                result = ui.opponent(state)
+                result = ui.opponent(state, self.message, self.show_all_candidates)
                 if result is None:
                     self.set_message("Cancelled `opponent`")
                     continue

--- a/ui.py
+++ b/ui.py
@@ -82,7 +82,7 @@ def show_possible_questions(state: State) -> list[Question]:
     id_width = len(str(len(questions) - 1)) + 2
     for q in questions:
         qid_max = max(qid_max, entire_east_asian_width(q.colored_question_label()))
-    print("Available questions:")
+    print(f"Available {len(questions)} questions:")
     print_border()
     for idx, q in enumerate(questions):
         colored_id_aligned = ljust_east_asian(q.colored_question_label(), qid_max)

--- a/ui.py
+++ b/ui.py
@@ -53,23 +53,26 @@ def aligned_question_cards(cards: list[QuestionCard]):
     ]
 
 
-def show_question_cards(cards: list[QuestionCard]):
+def show_question_cards(cards: list[QuestionCard], with_index=True):
     aligned = aligned_question_cards(cards)
     id_width = len(str(len(cards) - 1)) + 2
     for idx, (qc_id, qc_desc) in enumerate(aligned):
         idx_str = f"[{idx}]".ljust(id_width, " ")
-        print(f"{qc_id} {idx_str} {colorize(qc_desc)}")
+        if with_index:
+            print(f"{qc_id} {idx_str} {colorize(qc_desc)}")
+        else:
+            print(f"{qc_id} {colorize(qc_desc)}")
 
 
-def show_question_cards_in_deck(state: State):
+def show_question_cards_in_deck(state: State, with_index=True):
     print("Awaiting question cards:")
-    show_question_cards(state.question_cards_in_deck)
+    show_question_cards(state.question_cards_in_deck, with_index)
     print_border()
 
 
-def show_question_cards_in_field(state: State):
+def show_question_cards_in_field(state: State, with_index=True):
     print("Current question cards:")
-    show_question_cards(state.question_cards_in_field)
+    show_question_cards(state.question_cards_in_field, with_index)
     print_border()
 
 
@@ -193,7 +196,7 @@ def show_dashboard(state: State, message="", show_all=False):
     print(f"Your hand: {state.hand}")
     print_border()
     # Question cards section
-    show_question_cards_in_field(state)
+    show_question_cards_in_field(state, with_index=False)
     # Message section (if exists)
     if message:
         print(f"!! {message}")

--- a/ui.py
+++ b/ui.py
@@ -71,7 +71,7 @@ def show_question_cards_in_deck(state: State, with_index=True):
 
 
 def show_question_cards_in_field(state: State, with_index=True):
-    print("Current question cards:")
+    print(f"Current {len(state.question_cards_in_field)} question cards:")
     show_question_cards(state.question_cards_in_field, with_index)
     print_border()
 

--- a/ui.py
+++ b/ui.py
@@ -95,7 +95,6 @@ def show_possible_questions(state: State) -> list[Question]:
 
 def qa_list(state: State, question: Question) -> Answer | None:
     while True:
-        clear_view()
         print(f"Asked {question}")
         lis = input_where("Answer:")
         if lis is None:
@@ -105,7 +104,6 @@ def qa_list(state: State, question: Question) -> Answer | None:
 
 def qa_int(state: State, question: Question) -> Answer | None:
     while True:
-        clear_view()
         print(f"Asked {question}")
         num = input_int("Answer:")
         if num is None:
@@ -113,9 +111,10 @@ def qa_int(state: State, question: Question) -> Answer | None:
         return Answer(question.type, num)
 
 
-def qa(state: State) -> tuple[int, Question, Answer] | None:
+def qa(state: State, message="", show_all=False) -> tuple[int, Question, Answer] | None:
     while True:
         clear_view()
+        show_dashboard(state, message, show_all)
         questions = show_possible_questions(state)
         idx = input_int("Which question do you ask?")
         if idx is None:
@@ -138,9 +137,10 @@ def qa(state: State) -> tuple[int, Question, Answer] | None:
         return (idx, question, answer)
 
 
-def add(state: State) -> int | None:
+def add(state: State, message="", show_all=False) -> int | None:
     while True:
         clear_view()
+        show_dashboard(state, message, show_all)
         show_question_cards_in_deck(state)
         idx = input_int("which card has been added?")
         if idx is None:
@@ -151,9 +151,10 @@ def add(state: State) -> int | None:
             continue
 
 
-def opponent(state: State) -> tuple[int, Question, Answer | None] | None:
+def opponent(state: State, message="", show_all=False) -> tuple[int, Question, Answer | None] | None:
     while True:
         clear_view()
+        show_dashboard(state, message, show_all)
         questions = show_possible_questions(state)
         idx = input_int("Which question did the opponent ask?")
         if idx is None:


### PR DESCRIPTION
## Summary

Closes #29

This PR makes the dashboard view always be shown in command `question`, `add`, `opponent`.
You can consider that these commands no longer clear the view.
Also, the view is not cleared at the phase of inputting answer.
